### PR TITLE
Implement offline storage and caching

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,21 @@
+importScripts('https://storage.googleapis.com/workbox-cdn/releases/7.0.0/workbox-sw.js');
+
+workbox.core.skipWaiting();
+workbox.core.clientsClaim();
+
+workbox.precaching.precacheAndRoute(self.__WB_MANIFEST || []);
+
+workbox.routing.registerRoute(
+  ({request}) => ['script','style','worker'].includes(request.destination),
+  new workbox.strategies.StaleWhileRevalidate({
+    cacheName: 'asset-cache'
+  })
+);
+
+workbox.routing.registerRoute(
+  ({url}) => url.pathname.startsWith('/api/'),
+  new workbox.strategies.NetworkFirst({
+    cacheName: 'api-cache'
+  })
+);
+

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,10 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 import { registerServiceWorker } from './pwa';
+import { migrateLocalStorageToIndexedDB } from './utils/offlineStorage';
+
+// Migrate any existing data stored in localStorage to IndexedDB for offline use
+migrateLocalStorageToIndexedDB();
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -17,3 +21,4 @@ root.render(
 );
 
 registerServiceWorker();
+

--- a/src/utils/offlineStorage.ts
+++ b/src/utils/offlineStorage.ts
@@ -1,0 +1,121 @@
+import { openDB, DBSchema, IDBPDatabase } from 'idb';
+
+export interface OfflineQueueItem {
+  type: string;
+  payload: any;
+  timestamp: number;
+}
+
+interface OfflineDB extends DBSchema {
+  data: {
+    key: string;
+    value: any;
+  };
+  queue: {
+    key: number;
+    value: OfflineQueueItem;
+  };
+}
+
+const DB_NAME = 'offline-store';
+const DB_VERSION = 1;
+
+let dbPromise: Promise<IDBPDatabase<OfflineDB>> | null = null;
+
+export const isIndexedDBSupported = (): boolean => {
+  try {
+    return typeof indexedDB !== 'undefined';
+  } catch {
+    return false;
+  }
+};
+
+const getDB = async (): Promise<IDBPDatabase<OfflineDB>> => {
+  if (!dbPromise) {
+    dbPromise = openDB<OfflineDB>(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains('data')) {
+          db.createObjectStore('data');
+        }
+        if (!db.objectStoreNames.contains('queue')) {
+          db.createObjectStore('queue', { keyPath: 'id', autoIncrement: true });
+        }
+      }
+    }).catch(err => {
+      console.error('Failed to open IndexedDB', err);
+      dbPromise = null;
+      throw err;
+    });
+  }
+  return dbPromise;
+};
+
+export const saveData = async (key: string, value: any): Promise<void> => {
+  if (!isIndexedDBSupported()) {
+    localStorage.setItem(key, JSON.stringify(value));
+    return;
+  }
+  const db = await getDB();
+  await db.put('data', value, key);
+};
+
+export const loadData = async (key: string): Promise<any | null> => {
+  if (!isIndexedDBSupported()) {
+    const val = localStorage.getItem(key);
+    return val ? JSON.parse(val) : null;
+  }
+  const db = await getDB();
+  return db.get('data', key);
+};
+
+export const addToQueue = async (item: OfflineQueueItem): Promise<void> => {
+  if (!isIndexedDBSupported()) {
+    const queueStr = localStorage.getItem('offline-queue');
+    const queue = queueStr ? JSON.parse(queueStr) : [];
+    queue.push(item);
+    localStorage.setItem('offline-queue', JSON.stringify(queue));
+    return;
+  }
+  const db = await getDB();
+  await db.add('queue', item);
+};
+
+export const getQueue = async (): Promise<OfflineQueueItem[]> => {
+  if (!isIndexedDBSupported()) {
+    const queueStr = localStorage.getItem('offline-queue');
+    return queueStr ? JSON.parse(queueStr) : [];
+  }
+  const db = await getDB();
+  return db.getAll('queue');
+};
+
+export const clearQueue = async (): Promise<void> => {
+  if (!isIndexedDBSupported()) {
+    localStorage.removeItem('offline-queue');
+    return;
+  }
+  const db = await getDB();
+  const tx = db.transaction('queue', 'readwrite');
+  await tx.store.clear();
+  await tx.done;
+};
+
+export const migrateLocalStorageToIndexedDB = async (): Promise<void> => {
+  if (!isIndexedDBSupported()) return;
+  const tree = localStorage.getItem('concept-hierarchy-data');
+  const collapsed = localStorage.getItem('concept-hierarchy-collapsed-nodes');
+  if (tree) {
+    try {
+      await saveData('concept-hierarchy-data', JSON.parse(tree));
+    } catch (e) {
+      console.error('Failed to migrate tree data', e);
+    }
+  }
+  if (collapsed) {
+    try {
+      await saveData('concept-hierarchy-collapsed-nodes', JSON.parse(collapsed));
+    } catch (e) {
+      console.error('Failed to migrate collapsed nodes', e);
+    }
+  }
+};

--- a/src/utils/syncManager.ts
+++ b/src/utils/syncManager.ts
@@ -1,0 +1,16 @@
+import { addToQueue, getQueue, clearQueue, OfflineQueueItem } from './offlineStorage';
+
+export const enqueueChange = async (type: string, payload: any): Promise<void> => {
+  const item: OfflineQueueItem = {
+    type,
+    payload,
+    timestamp: Date.now()
+  };
+  await addToQueue(item);
+};
+
+export const drainQueue = async (): Promise<OfflineQueueItem[]> => {
+  const items = await getQueue();
+  await clearQueue();
+  return items;
+};

--- a/tasks/tasks-PRD-offline-pwa-sync.md
+++ b/tasks/tasks-PRD-offline-pwa-sync.md
@@ -34,13 +34,13 @@
   - [x] 1.5 Add PWA meta tags to index.html
   - [x] 1.6 Test PWA installability in supported browsers
 
-- [ ] 2.0 Offline Storage & Caching Implementation
-  - [ ] 2.1 Create IndexedDB wrapper utility for offline data storage
-  - [ ] 2.2 Implement service worker with Workbox for asset caching
-  - [ ] 2.3 Add runtime caching strategies for API calls
-  - [ ] 2.4 Create offline queue system for pending changes
-  - [ ] 2.5 Migrate existing localStorage data to IndexedDB
-  - [ ] 2.6 Add fallback mechanisms for when IndexedDB is unavailable
+- [x] 2.0 Offline Storage & Caching Implementation
+  - [x] 2.1 Create IndexedDB wrapper utility for offline data storage
+  - [x] 2.2 Implement service worker with Workbox for asset caching
+  - [x] 2.3 Add runtime caching strategies for API calls
+  - [x] 2.4 Create offline queue system for pending changes
+  - [x] 2.5 Migrate existing localStorage data to IndexedDB
+  - [x] 2.6 Add fallback mechanisms for when IndexedDB is unavailable
 
 - [ ] 3.0 Background Sync & Conflict Resolution
   - [ ] 3.1 Implement background sync service worker registration


### PR DESCRIPTION
## Summary
- add IndexedDB wrapper and offline queue utilities
- create Workbox-based service worker with asset/API caching
- migrate existing localStorage data at startup
- mark offline storage tasks complete

## Testing
- `npx jest` *(fails: needs jest install)*

------
https://chatgpt.com/codex/tasks/task_e_684535dd0a90833392057a5386191622